### PR TITLE
Harden legacy ApplyAttributeUpdates and reject type-mismatched ADD (#28)

### DIFF
--- a/src/DynamoDbLite/DynamoDbClient.Crud.cs
+++ b/src/DynamoDbLite/DynamoDbClient.Crud.cs
@@ -271,7 +271,7 @@ public sealed partial class DynamoDbClient
         }
         else if (request.AttributeUpdates is { Count: > 0 })
         {
-            existingItem = ApplyAttributeUpdates(existingItem, request.AttributeUpdates);
+            existingItem = ApplyAttributeUpdates(existingItem, request.AttributeUpdates, keyInfo);
         }
 
         var itemJson = AttributeValueSerializer.Serialize(existingItem);
@@ -334,8 +334,18 @@ public sealed partial class DynamoDbClient
     [ExcludeFromCodeCoverage(Justification = "Deprecated AWS DynamoDB AttributeUpdates API — superseded by UpdateExpression")]
     private static Dictionary<string, AttributeValue> ApplyAttributeUpdates(
         Dictionary<string, AttributeValue> item,
-        Dictionary<string, AttributeValueUpdate> attributeUpdates)
+        Dictionary<string, AttributeValueUpdate> attributeUpdates,
+        KeySchemaInfo keyInfo)
     {
+        // Key attributes cannot be modified through UpdateItem — reject any attempt, matching the
+        // UpdateExpression path and real DynamoDB.
+        foreach (var key in keyInfo.KeySchema)
+        {
+            if (attributeUpdates.ContainsKey(key.AttributeName))
+                throw new AmazonDynamoDBException(
+                    $"One or more parameter values were invalid: Cannot update attribute {key.AttributeName}. This attribute is part of the key");
+        }
+
         var result = new Dictionary<string, AttributeValue>(item);
         foreach (var (attrName, update) in attributeUpdates)
         {
@@ -364,9 +374,19 @@ public sealed partial class DynamoDbClient
                     }
 
                     break;
-                case "ADD" when update.Value.N is not null:
-                    if (result.TryGetValue(attrName, out var numVal) && numVal.N is not null)
+                case "DELETE" when update.Value.BS is { Count: > 0 }:
+                    if (result.TryGetValue(attrName, out var bsVal) && bsVal.BS is not null)
                     {
+                        foreach (var b in update.Value.BS)
+                            Expressions.ExpressionHelper.BinarySetRemoveAll(bsVal.BS, b);
+                    }
+
+                    break;
+                case "ADD" when update.Value.N is not null:
+                    if (result.TryGetValue(attrName, out var numVal))
+                    {
+                        if (numVal.N is null)
+                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a number requires an existing number");
                         var current = double.Parse(numVal.N, CultureInfo.InvariantCulture);
                         var addend = double.Parse(update.Value.N, CultureInfo.InvariantCulture);
                         result[attrName] = new AttributeValue { N = (current + addend).ToString(CultureInfo.InvariantCulture) };
@@ -378,16 +398,49 @@ public sealed partial class DynamoDbClient
 
                     break;
                 case "ADD" when update.Value.SS is { Count: > 0 }:
-                    if (result.TryGetValue(attrName, out var addSsVal) && addSsVal.SS is not null)
-                        addSsVal.SS.AddRange(update.Value.SS);
+                    if (result.TryGetValue(attrName, out var addSsVal))
+                    {
+                        if (addSsVal.SS is null)
+                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a string set requires an existing string set");
+                        foreach (var s in update.Value.SS)
+                            if (!addSsVal.SS.Contains(s))
+                                addSsVal.SS.Add(s);
+                    }
                     else
+                    {
                         result[attrName] = update.Value;
+                    }
+
                     break;
                 case "ADD" when update.Value.NS is { Count: > 0 }:
-                    if (result.TryGetValue(attrName, out var addNsVal) && addNsVal.NS is not null)
-                        addNsVal.NS.AddRange(update.Value.NS);
+                    if (result.TryGetValue(attrName, out var addNsVal))
+                    {
+                        if (addNsVal.NS is null)
+                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a number set requires an existing number set");
+                        foreach (var n in update.Value.NS)
+                            if (!addNsVal.NS.Contains(n))
+                                addNsVal.NS.Add(n);
+                    }
                     else
+                    {
                         result[attrName] = update.Value;
+                    }
+
+                    break;
+                case "ADD" when update.Value.BS is { Count: > 0 }:
+                    if (result.TryGetValue(attrName, out var addBsVal))
+                    {
+                        if (addBsVal.BS is null)
+                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a binary set requires an existing binary set");
+                        foreach (var b in update.Value.BS)
+                            if (!Expressions.ExpressionHelper.BinarySetContains(addBsVal.BS, b))
+                                addBsVal.BS.Add(b);
+                    }
+                    else
+                    {
+                        result[attrName] = update.Value;
+                    }
+
                     break;
                 default:
                     result[attrName] = update.Value;

--- a/src/DynamoDbLite/DynamoDbClient.Crud.cs
+++ b/src/DynamoDbLite/DynamoDbClient.Crud.cs
@@ -386,7 +386,7 @@ public sealed partial class DynamoDbClient
                     if (result.TryGetValue(attrName, out var numVal))
                     {
                         if (numVal.N is null)
-                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a number requires an existing number");
+                            throw new AmazonDynamoDBException("Type mismatch for attribute to update");
                         var current = double.Parse(numVal.N, CultureInfo.InvariantCulture);
                         var addend = double.Parse(update.Value.N, CultureInfo.InvariantCulture);
                         result[attrName] = new AttributeValue { N = (current + addend).ToString(CultureInfo.InvariantCulture) };
@@ -401,7 +401,7 @@ public sealed partial class DynamoDbClient
                     if (result.TryGetValue(attrName, out var addSsVal))
                     {
                         if (addSsVal.SS is null)
-                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a string set requires an existing string set");
+                            throw new AmazonDynamoDBException("Type mismatch for attribute to update");
                         foreach (var s in update.Value.SS)
                             if (!addSsVal.SS.Contains(s))
                                 addSsVal.SS.Add(s);
@@ -416,7 +416,7 @@ public sealed partial class DynamoDbClient
                     if (result.TryGetValue(attrName, out var addNsVal))
                     {
                         if (addNsVal.NS is null)
-                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a number set requires an existing number set");
+                            throw new AmazonDynamoDBException("Type mismatch for attribute to update");
                         foreach (var n in update.Value.NS)
                             if (!addNsVal.NS.Contains(n))
                                 addNsVal.NS.Add(n);
@@ -431,7 +431,7 @@ public sealed partial class DynamoDbClient
                     if (result.TryGetValue(attrName, out var addBsVal))
                     {
                         if (addBsVal.BS is null)
-                            throw new AmazonDynamoDBException($"Type mismatch for attribute {attrName}: ADD of a binary set requires an existing binary set");
+                            throw new AmazonDynamoDBException("Type mismatch for attribute to update");
                         foreach (var b in update.Value.BS)
                             if (!Expressions.ExpressionHelper.BinarySetContains(addBsVal.BS, b))
                                 addBsVal.BS.Add(b);

--- a/src/DynamoDbLite/Expressions/ExpressionHelper.cs
+++ b/src/DynamoDbLite/Expressions/ExpressionHelper.cs
@@ -172,6 +172,34 @@ internal static class ExpressionHelper
         }
     }
 
+    // Binary sets compare by content, not by MemoryStream reference, so set ADD/DELETE must
+    // compare the underlying bytes. Shared by the UpdateExpression evaluator and the legacy
+    // AttributeUpdates path.
+    internal static bool BinarySetContains(List<MemoryStream> set, MemoryStream value)
+    {
+        var valueSpan = GetSpan(value);
+        foreach (var item in set)
+        {
+            if (GetSpan(item).SequenceEqual(valueSpan))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static void BinarySetRemoveAll(List<MemoryStream> set, MemoryStream value)
+    {
+        var valueSpan = GetSpan(value);
+        for (var i = set.Count - 1; i >= 0; i--)
+        {
+            if (GetSpan(set[i]).SequenceEqual(valueSpan))
+                set.RemoveAt(i);
+        }
+    }
+
+    private static ReadOnlySpan<byte> GetSpan(MemoryStream ms) =>
+        ms.TryGetBuffer(out var segment) ? segment.AsSpan() : ms.ToArray(); // streams created via ReadableStream always expose their buffer
+
     private static InvalidOperationException UnhandledPathElement(PathElement element) =>
         new($"Unhandled PathElement: {element.GetType().Name}");
 

--- a/src/DynamoDbLite/Expressions/UpdateExpressionEvaluator.cs
+++ b/src/DynamoDbLite/Expressions/UpdateExpressionEvaluator.cs
@@ -1,3 +1,4 @@
+using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using System.Globalization;
 
@@ -41,31 +42,6 @@ internal static class UpdateExpressionEvaluator
         }
 
         return (item, modifiedKeys);
-    }
-
-    private static ReadOnlySpan<byte> GetSpan(MemoryStream ms) =>
-        ms.TryGetBuffer(out var segment) ? segment.AsSpan() : ms.ToArray(); // defensive: streams created via ReadableStream always expose buffer
-
-    private static bool BinarySetContains(List<MemoryStream> set, MemoryStream value)
-    {
-        var valueSpan = GetSpan(value);
-        foreach (var item in set)
-        {
-            if (GetSpan(item).SequenceEqual(valueSpan))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static void BinarySetRemoveAll(List<MemoryStream> set, MemoryStream value)
-    {
-        var valueSpan = GetSpan(value);
-        for (var i = set.Count - 1; i >= 0; i--)
-        {
-            if (GetSpan(set[i]).SequenceEqual(valueSpan))
-                set.RemoveAt(i);
-        }
     }
 
     private static string GetTopLevelKey(AttributePath path, Dictionary<string, string>? expressionAttributeNames)
@@ -192,9 +168,16 @@ internal static class UpdateExpressionEvaluator
             // Binary set union
             foreach (var b in addValue.BS)
             {
-                if (!BinarySetContains(existing.BS, b))
+                if (!ExpressionHelper.BinarySetContains(existing.BS, b))
                     existing.BS.Add(b);
             }
+        }
+        else
+        {
+            // ADD onto an existing attribute of an incompatible type — DynamoDB rejects this
+            // rather than silently overwriting or ignoring it.
+            throw new AmazonDynamoDBException(
+                "An operand in the update expression has an incorrect data type");
         }
     }
 
@@ -221,7 +204,7 @@ internal static class UpdateExpressionEvaluator
         else if (existing.BS is not null && deleteValue.BS is not null)
         {
             foreach (var b in deleteValue.BS)
-                BinarySetRemoveAll(existing.BS, b);
+                ExpressionHelper.BinarySetRemoveAll(existing.BS, b);
         }
     }
 }

--- a/tests/DynamoDbLite.Tests/Expressions/UpdateExpressionTests.cs
+++ b/tests/DynamoDbLite.Tests/Expressions/UpdateExpressionTests.cs
@@ -188,6 +188,29 @@ public sealed class UpdateExpressionTests
         Assert.Contains("c", result["tags"].SS);
     }
 
+    [Fact]
+    public void Add_MismatchedType_Throws()
+    {
+        // ADD a number set onto an attribute stored as a string set. Real DynamoDB
+        // rejects the operand-type mismatch rather than overwriting the attribute.
+        var item = new Dictionary<string, AttributeValue>
+        {
+            ["PK"] = new() { S = "USER#1" },
+            ["tags"] = new() { SS = ["a", "b"] }
+        };
+
+        var ast = UpdateExpressionParser.Parse("ADD tags :nums");
+        var ex = Assert.Throws<AmazonDynamoDBException>(() =>
+            UpdateExpressionEvaluator.Apply(
+                ast, item, null,
+                new Dictionary<string, AttributeValue> { [":nums"] = new() { NS = ["1", "2"] } }));
+
+        Assert.Contains("incorrect data type", ex.Message, StringComparison.Ordinal);
+
+        // The original set must be left intact — no partial overwrite.
+        Assert.Equal(["a", "b"], item["tags"].SS.OrderBy(static s => s, StringComparer.Ordinal));
+    }
+
     // ── DELETE ──────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/DynamoDbLite.Tests/LegacyAttributeUpdatesTests.cs
+++ b/tests/DynamoDbLite.Tests/LegacyAttributeUpdatesTests.cs
@@ -198,6 +198,48 @@ public sealed class LegacyAttributeUpdatesTests
         Assert.Equal(["0A", "0C"], HexSet(item["blobs"].BS));
     }
 
+    // ── Defect 5: ADD onto a mismatched existing type must be rejected ─────
+    // Real DynamoDB rejects an ADD whose operand type differs from the stored
+    // attribute (e.g. ADD a number set onto an existing string set) instead of
+    // silently overwriting. The legacy path's per-type ADD cases fall through to
+    // the else branch and clobber the attribute with the operand. The modern
+    // UpdateExpression path already throws here — this brings parity.
+
+    [Theory]
+    [InlineData(StoreType.DdbLite)]
+    [InlineData(StoreType.DdbLiteFile)]
+    public async Task AttributeUpdates_AddMismatchedSetType_ThrowsAndLeavesItemIntact(StoreType st)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", new Dictionary<string, AttributeValue>
+        {
+            ["colors"] = new() { SS = ["red", "green"] }
+        });
+
+        // ADD a number set onto an attribute that is stored as a string set.
+        _ = await Assert.ThrowsAsync<AmazonDynamoDBException>(() =>
+            client.UpdateItemAsync(new UpdateItemRequest
+            {
+                TableName = TestTableName,
+                Key = Key("USER#1", "PROFILE"),
+                AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+                {
+                    ["colors"] = new()
+                    {
+                        Action = AttributeAction.ADD,
+                        Value = new AttributeValue { NS = ["1", "2"] }
+                    }
+                }
+            }, ct));
+
+        // The reject must be atomic: the stored string set is untouched, not
+        // overwritten with the number set.
+        var item = await GetItemAsync(client, "USER#1", "PROFILE", ct);
+        Assert.Equal(["green", "red"], item["colors"].SS.OrderBy(static s => s, StringComparer.Ordinal));
+        Assert.True(item["colors"].NS is null or { Count: 0 });
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     private static Dictionary<string, AttributeValue> Key(string pk, string sk) => new()

--- a/tests/DynamoDbLite.Tests/LegacyAttributeUpdatesTests.cs
+++ b/tests/DynamoDbLite.Tests/LegacyAttributeUpdatesTests.cs
@@ -1,0 +1,223 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using DynamoDbLite.Tests.Fixtures;
+
+namespace DynamoDbLite.Tests;
+
+// Regression coverage for issue #28: harden the legacy ApplyAttributeUpdates path
+// (UpdateItemRequest.AttributeUpdates, the deprecated AWS API still used by the
+// DynamoDBContext Document Model layer). Each theory asserts real-DynamoDB behavior,
+// so it fails against the current defect and guards against its return after the fix.
+public sealed class LegacyAttributeUpdatesTests
+    : DynamoDbClientFixture
+{
+    protected override async ValueTask SetupAsync(CancellationToken ct)
+    {
+        await CreateTestTableAsync(Client(StoreType.DdbLite), ct);
+        await CreateTestTableAsync(Client(StoreType.DdbLiteFile), ct);
+    }
+
+    // ── Defect 1: key attributes can be silently overwritten ───────────────
+    // Real DynamoDB rejects an AttributeUpdates entry that targets a key attribute
+    // (PK/SK). The legacy path skips the key-validation the UpdateExpression path does,
+    // so it silently rewrites the key in-place and corrupts the stored item.
+
+    [Theory]
+    [InlineData(StoreType.DdbLite, "PK")]
+    [InlineData(StoreType.DdbLite, "SK")]
+    [InlineData(StoreType.DdbLiteFile, "PK")]
+    [InlineData(StoreType.DdbLiteFile, "SK")]
+    public async Task AttributeUpdates_PutOnKeyAttribute_ThrowsException(StoreType st, string keyAttribute)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", []);
+
+        _ = await Assert.ThrowsAsync<AmazonDynamoDBException>(() =>
+            client.UpdateItemAsync(new UpdateItemRequest
+            {
+                TableName = TestTableName,
+                Key = Key("USER#1", "PROFILE"),
+                AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+                {
+                    [keyAttribute] = new()
+                    {
+                        Action = AttributeAction.PUT,
+                        Value = new AttributeValue { S = "MUTATED" }
+                    }
+                }
+            }, ct));
+    }
+
+    // ── Defect 2: ADD to a string/number set must enforce set uniqueness ───
+    // Real DynamoDB treats SS/NS as mathematical sets; ADD unions and dedups.
+    // The legacy path uses List.AddRange, leaving duplicates behind.
+
+    [Theory]
+    [InlineData(StoreType.DdbLite)]
+    [InlineData(StoreType.DdbLiteFile)]
+    public async Task AttributeUpdates_AddToStringSet_DeduplicatesOverlap(StoreType st)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", new Dictionary<string, AttributeValue>
+        {
+            ["colors"] = new() { SS = ["red", "green"] }
+        });
+
+        _ = await client.UpdateItemAsync(new UpdateItemRequest
+        {
+            TableName = TestTableName,
+            Key = Key("USER#1", "PROFILE"),
+            AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+            {
+                ["colors"] = new()
+                {
+                    Action = AttributeAction.ADD,
+                    Value = new AttributeValue { SS = ["green", "blue"] }
+                }
+            }
+        }, ct);
+
+        var item = await GetItemAsync(client, "USER#1", "PROFILE", ct);
+        Assert.Equal(["blue", "green", "red"], item["colors"].SS.OrderBy(static s => s, StringComparer.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(StoreType.DdbLite)]
+    [InlineData(StoreType.DdbLiteFile)]
+    public async Task AttributeUpdates_AddToNumberSet_DeduplicatesOverlap(StoreType st)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", new Dictionary<string, AttributeValue>
+        {
+            ["scores"] = new() { NS = ["1", "2"] }
+        });
+
+        _ = await client.UpdateItemAsync(new UpdateItemRequest
+        {
+            TableName = TestTableName,
+            Key = Key("USER#1", "PROFILE"),
+            AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+            {
+                ["scores"] = new()
+                {
+                    Action = AttributeAction.ADD,
+                    Value = new AttributeValue { NS = ["2", "3"] }
+                }
+            }
+        }, ct);
+
+        var item = await GetItemAsync(client, "USER#1", "PROFILE", ct);
+        Assert.Equal(["1", "2", "3"], item["scores"].NS.OrderBy(static n => n, StringComparer.Ordinal));
+    }
+
+    // ── Defect 3: ADD to a binary set is unhandled and overwrites ──────────
+    // Real DynamoDB unions BS the same way it does SS/NS. The legacy path has no
+    // BS case, so ADD falls through to the default and replaces the whole set with
+    // only the added elements.
+
+    [Theory]
+    [InlineData(StoreType.DdbLite)]
+    [InlineData(StoreType.DdbLiteFile)]
+    public async Task AttributeUpdates_AddToBinarySet_UnionsValues(StoreType st)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        byte[] a = [0x0A], b = [0x0B], c = [0x0C];
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", new Dictionary<string, AttributeValue>
+        {
+            ["blobs"] = new() { BS = [new MemoryStream(a), new MemoryStream(b)] }
+        });
+
+        _ = await client.UpdateItemAsync(new UpdateItemRequest
+        {
+            TableName = TestTableName,
+            Key = Key("USER#1", "PROFILE"),
+            AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+            {
+                ["blobs"] = new()
+                {
+                    Action = AttributeAction.ADD,
+                    Value = new AttributeValue { BS = [new MemoryStream(b), new MemoryStream(c)] }
+                }
+            }
+        }, ct);
+
+        var item = await GetItemAsync(client, "USER#1", "PROFILE", ct);
+        Assert.Equal(["0A", "0B", "0C"], HexSet(item["blobs"].BS));
+    }
+
+    // ── Defect 4: DELETE from a binary set is unhandled and overwrites ─────
+    // Real DynamoDB removes the named elements from BS. The legacy path has no BS
+    // DELETE case, so it falls through to the default and replaces the attribute
+    // with the delete-set itself.
+
+    [Theory]
+    [InlineData(StoreType.DdbLite)]
+    [InlineData(StoreType.DdbLiteFile)]
+    public async Task AttributeUpdates_DeleteFromBinarySet_RemovesElements(StoreType st)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        byte[] a = [0x0A], b = [0x0B], c = [0x0C];
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", new Dictionary<string, AttributeValue>
+        {
+            ["blobs"] = new() { BS = [new MemoryStream(a), new MemoryStream(b), new MemoryStream(c)] }
+        });
+
+        _ = await client.UpdateItemAsync(new UpdateItemRequest
+        {
+            TableName = TestTableName,
+            Key = Key("USER#1", "PROFILE"),
+            AttributeUpdates = new Dictionary<string, AttributeValueUpdate>
+            {
+                ["blobs"] = new()
+                {
+                    Action = AttributeAction.DELETE,
+                    Value = new AttributeValue { BS = [new MemoryStream(b)] }
+                }
+            }
+        }, ct);
+
+        var item = await GetItemAsync(client, "USER#1", "PROFILE", ct);
+        Assert.Equal(["0A", "0C"], HexSet(item["blobs"].BS));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static Dictionary<string, AttributeValue> Key(string pk, string sk) => new()
+    {
+        ["PK"] = new() { S = pk },
+        ["SK"] = new() { S = sk }
+    };
+
+    private Task<PutItemResponse> PutItemAsync(
+        DynamoDbClient client, string pk, string sk, Dictionary<string, AttributeValue> extra)
+    {
+        var item = Key(pk, sk);
+        foreach (var (k, v) in extra)
+            item[k] = v;
+        return client.PutItemAsync(new PutItemRequest
+        {
+            TableName = TestTableName,
+            Item = item
+        }, TestContext.Current.CancellationToken);
+    }
+
+    private async Task<Dictionary<string, AttributeValue>> GetItemAsync(
+        DynamoDbClient client, string pk, string sk, CancellationToken ct)
+    {
+        var response = await client.GetItemAsync(new GetItemRequest
+        {
+            TableName = TestTableName,
+            Key = Key(pk, sk)
+        }, ct);
+        return response.Item;
+    }
+
+    private static IEnumerable<string> HexSet(IEnumerable<MemoryStream> streams) =>
+        streams.Select(static s => Convert.ToHexString(s.ToArray()))
+            .OrderBy(static h => h, StringComparer.Ordinal);
+}

--- a/tests/DynamoDbLite.Tests/LegacyAttributeUpdatesTests.cs
+++ b/tests/DynamoDbLite.Tests/LegacyAttributeUpdatesTests.cs
@@ -31,9 +31,12 @@ public sealed class LegacyAttributeUpdatesTests
     {
         var client = Client(st);
         var ct = TestContext.Current.CancellationToken;
-        _ = await PutItemAsync(client, "USER#1", "PROFILE", []);
+        _ = await PutItemAsync(client, "USER#1", "PROFILE", new Dictionary<string, AttributeValue>
+        {
+            ["status"] = new() { S = "active" }
+        });
 
-        _ = await Assert.ThrowsAsync<AmazonDynamoDBException>(() =>
+        var ex = await Assert.ThrowsAsync<AmazonDynamoDBException>(() =>
             client.UpdateItemAsync(new UpdateItemRequest
             {
                 TableName = TestTableName,
@@ -47,6 +50,16 @@ public sealed class LegacyAttributeUpdatesTests
                     }
                 }
             }, ct));
+
+        Assert.Contains(keyAttribute, ex.Message, StringComparison.Ordinal);
+
+        // The reject must be atomic: the original item is left fully intact, with no
+        // partial write of the rejected key or any other attribute.
+        var item = await GetItemAsync(client, "USER#1", "PROFILE", ct);
+        Assert.Equal("USER#1", item["PK"].S);
+        Assert.Equal("PROFILE", item["SK"].S);
+        Assert.Equal("active", item["status"].S);
+        Assert.DoesNotContain("MUTATED", item.Values.Select(static v => v.S));
     }
 
     // ── Defect 2: ADD to a string/number set must enforce set uniqueness ───


### PR DESCRIPTION
Closes #28

## Summary

Hardens the deprecated `AttributeUpdates` path in `UpdateItemAsync` to match real DynamoDB semantics, and closes a related set-handling parity gap that the modern `UpdateExpression` path shared.

### Defects fixed (#28)

1. **Key-attribute overwrite (high severity).** `ApplyAttributeUpdates` had no key validation, so an update targeting a PK/SK attribute silently desynced the `pk`/`sk` index columns from the value embedded in `item_json` — producing a row unretrievable by its own claimed key. Now rejected with `AmazonDynamoDBException`, identical to the `UpdateExpression` path.
2. **SS/NS set uniqueness.** `ADD` used `AddRange`, leaving duplicate members in the set (sets are stored inside `item_json`, so SQLite never deduped them). Now a `Contains`-before-add union.
3. **Binary sets (BS).** `ADD` was unhandled and `DELETE` fell through to overwrite the whole set. Both now handled (union / content-wise remove).

### Related fix (type-mismatched ADD)

`ADD` onto an existing attribute of an incompatible type (e.g. `ADD` an `NS` onto an existing `SS`) previously **silently overwrote** on the legacy path and **silently no-op'd** on the modern path. Both now throw `AmazonDynamoDBException`, matching DynamoDB. This is broader than #28 (it touches the shared `UpdateExpression` path) — noting it here rather than leaving it implicit.

### Refactor

Binary-set comparison helpers (`BinarySetContains` / `BinarySetRemoveAll`) moved from `UpdateExpressionEvaluator` (where they were `private`) into the shared `ExpressionHelper`, so both paths use one implementation.

## Tests

- `LegacyAttributeUpdatesTests` — regression coverage for all four #28 defects, parametrized over both store backends.
- New type-mismatch coverage in `LegacyAttributeUpdatesTests` and `UpdateExpressionTests` (mismatch throws; create-on-missing and same-type union still pass).
- Full suite green: 847 + 192 passing, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)