### PR TITLE
Fail import on a missing source, not on a valid empty export (#17)

### DIFF
--- a/src/DynamoDbLite/DynamoDbClient.Import.cs
+++ b/src/DynamoDbLite/DynamoDbClient.Import.cs
@@ -87,6 +87,18 @@ public sealed partial class DynamoDbClient
                 : Path.Combine(s3Bucket, s3KeyPrefix);
             var dataFiles = ExportHelper.FindDataFiles(basePath);
 
+            // Real DynamoDB fails the import when the source has no importable data.
+            // Without this check an empty/wrong source path would complete with
+            // importedCount=0 and status COMPLETED, hiding the misconfiguration.
+            if (dataFiles.Count == 0)
+            {
+                var failTime = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+                await store.UpdateImportStatusAsync(
+                    importArn, "FAILED", failTime, null, null, null, null,
+                    "S3NoSuchKey", "No data files found at the specified S3 location");
+                return;
+            }
+
             long importedCount = 0;
             long processedCount = 0;
             long processedBytes = 0;

--- a/src/DynamoDbLite/DynamoDbClient.Import.cs
+++ b/src/DynamoDbLite/DynamoDbClient.Import.cs
@@ -85,19 +85,23 @@ public sealed partial class DynamoDbClient
             var basePath = string.IsNullOrEmpty(s3KeyPrefix)
                 ? s3Bucket
                 : Path.Combine(s3Bucket, s3KeyPrefix);
-            var dataFiles = ExportHelper.FindDataFiles(basePath);
 
-            // Real DynamoDB fails the import when the source has no importable data.
-            // Without this check an empty/wrong source path would complete with
-            // importedCount=0 and status COMPLETED, hiding the misconfiguration.
-            if (dataFiles.Count == 0)
+            // Real DynamoDB fails an import only when the source location itself is missing
+            // or inaccessible (FailureCode S3NoSuchBucket) — a valid export that happens to
+            // contain zero items imports successfully with 0 items. DynamoDbLite reuses the
+            // S3Bucket field as a local path, so the analog of "the source doesn't exist" is
+            // the absence of an AWSDynamoDB export directory at the path. A present export
+            // with no data files (an empty-table export) is left to import as 0 items.
+            if (!Directory.Exists(Path.Combine(basePath, "AWSDynamoDB")))
             {
                 var failTime = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture);
                 await store.UpdateImportStatusAsync(
                     importArn, "FAILED", failTime, null, null, null, null,
-                    "S3NoSuchKey", "No data files found at the specified S3 location");
+                    "S3NoSuchBucket", "The specified S3 location does not exist");
                 return;
             }
+
+            var dataFiles = ExportHelper.FindDataFiles(basePath);
 
             long importedCount = 0;
             long processedCount = 0;

--- a/tests/DynamoDbLite.Tests/ExportImportRoundTripTests.cs
+++ b/tests/DynamoDbLite.Tests/ExportImportRoundTripTests.cs
@@ -191,6 +191,104 @@ public sealed class ExportImportRoundTripTests
     [Theory]
     [InlineData(StoreType.DdbLiteFile)]
     [InlineData(StoreType.DdbLite)]
+    public async Task Export_And_Import_Empty_Table_Completes_With_Zero_Items(StoreType st)
+    {
+        var client = Client(st);
+        var ct = TestContext.Current.CancellationToken;
+        const string sourceTable = "EmptyRoundTripSource";
+        const string sourceArn = "arn:aws:dynamodb:local:000000000000:table/EmptyRoundTripSource";
+        const string targetTable = "EmptyRoundTripTarget";
+
+        // Create the source table but leave it EMPTY — no PutItem calls.
+        _ = await client.CreateTableAsync(new CreateTableRequest
+        {
+            TableName = sourceTable,
+            KeySchema =
+            [
+                new KeySchemaElement { AttributeName = "PK", KeyType = KeyType.HASH },
+                new KeySchemaElement { AttributeName = "SK", KeyType = KeyType.RANGE }
+            ],
+            AttributeDefinitions =
+            [
+                new AttributeDefinition { AttributeName = "PK", AttributeType = ScalarAttributeType.S },
+                new AttributeDefinition { AttributeName = "SK", AttributeType = ScalarAttributeType.S }
+            ]
+        }, ct);
+
+        // Export the empty table — this produces a valid AWSDynamoDB export with zero data rows.
+        var exportResponse = await client.ExportTableToPointInTimeAsync(new ExportTableToPointInTimeRequest
+        {
+            TableArn = sourceArn,
+            S3Bucket = tempDir,
+            ExportFormat = ExportFormat.DYNAMODB_JSON
+        }, ct);
+
+        ExportStatus? exportFinalStatus = null;
+        for (var i = 0; i < 100; i++)
+        {
+            await Task.Delay(100, ct);
+            var desc = await client.DescribeExportAsync(new DescribeExportRequest
+            {
+                ExportArn = exportResponse.ExportDescription.ExportArn
+            }, ct);
+            if (desc.ExportDescription.ExportStatus != ExportStatus.IN_PROGRESS)
+            {
+                exportFinalStatus = desc.ExportDescription.ExportStatus;
+                break;
+            }
+        }
+
+        Assert.Equal(ExportStatus.COMPLETED, exportFinalStatus);
+
+        // Import from that same valid (but empty) export location.
+        var importResponse = await client.ImportTableAsync(new ImportTableRequest
+        {
+            S3BucketSource = new S3BucketSource { S3Bucket = tempDir },
+            InputFormat = InputFormat.DYNAMODB_JSON,
+            TableCreationParameters = new TableCreationParameters
+            {
+                TableName = targetTable,
+                KeySchema =
+                [
+                    new KeySchemaElement { AttributeName = "PK", KeyType = KeyType.HASH },
+                    new KeySchemaElement { AttributeName = "SK", KeyType = KeyType.RANGE }
+                ],
+                AttributeDefinitions =
+                [
+                    new AttributeDefinition { AttributeName = "PK", AttributeType = ScalarAttributeType.S },
+                    new AttributeDefinition { AttributeName = "SK", AttributeType = ScalarAttributeType.S }
+                ]
+            }
+        }, ct);
+
+        ImportTableDescription? importDescription = null;
+        for (var i = 0; i < 100; i++)
+        {
+            await Task.Delay(100, ct);
+            var desc = await client.DescribeImportAsync(new DescribeImportRequest
+            {
+                ImportArn = importResponse.ImportTableDescription.ImportArn
+            }, ct);
+            importDescription = desc.ImportTableDescription;
+            if (importDescription.ImportStatus != ImportStatus.IN_PROGRESS)
+                break;
+        }
+
+        Assert.NotNull(importDescription);
+
+        // A valid-but-empty export is not a misconfiguration. Real DynamoDB completes such an
+        // import successfully with zero imported items — it does NOT fail it.
+        Assert.Equal(ImportStatus.COMPLETED, importDescription.ImportStatus);
+        Assert.Equal(0, importDescription.ImportedItemCount);
+
+        // The imported table exists and is empty.
+        var scanResponse = await client.ScanAsync(new ScanRequest { TableName = targetTable }, ct);
+        Assert.Equal(0, scanResponse.Count);
+    }
+
+    [Theory]
+    [InlineData(StoreType.DdbLiteFile)]
+    [InlineData(StoreType.DdbLite)]
     public async Task Export_And_Import_With_GSI_PreservesIndex(StoreType st)
     {
         var client = Client(st);

--- a/tests/DynamoDbLite.Tests/ImportTests.cs
+++ b/tests/DynamoDbLite.Tests/ImportTests.cs
@@ -364,10 +364,11 @@ public abstract class ImportTestsBase
 
         var description = await ImportAndWaitForTerminalStatusAsync(missingPath, "ImportMissingPathTable");
 
-        // Real DynamoDB fails an import whose source location has no valid data files.
-        // It must not silently report COMPLETED with zero items.
+        // Real DynamoDB fails an import whose source location does not exist / has no export.
+        // The documented failure code for a missing source is S3NoSuchBucket.
         Assert.Equal(ImportStatus.FAILED, description.ImportStatus);
         Assert.Equal(0, description.ImportedItemCount);
+        Assert.Equal("S3NoSuchBucket", description.FailureCode);
     }
 
     [Fact]
@@ -379,10 +380,12 @@ public abstract class ImportTestsBase
         {
             var description = await ImportAndWaitForTerminalStatusAsync(emptyPath, "ImportEmptyPathTable");
 
-            // Source path exists but contains no data files — must surface a failure,
-            // not a silent COMPLETED-with-zero-items success.
+            // Source directory exists but holds no AWSDynamoDB export structure — there is no
+            // export at this location, so DynamoDB fails it with the missing-source code
+            // S3NoSuchBucket, not a silent COMPLETED-with-zero-items success.
             Assert.Equal(ImportStatus.FAILED, description.ImportStatus);
             Assert.Equal(0, description.ImportedItemCount);
+            Assert.Equal("S3NoSuchBucket", description.FailureCode);
         }
         finally
         {

--- a/tests/DynamoDbLite.Tests/ImportTests.cs
+++ b/tests/DynamoDbLite.Tests/ImportTests.cs
@@ -321,6 +321,82 @@ public abstract class ImportTestsBase
         Assert.All(response.ImportSummaryList, s => Assert.Equal(targetArn, s.TableArn));
     }
 
+    private async Task<ImportTableDescription> ImportAndWaitForTerminalStatusAsync(
+        string s3Bucket, string tableName)
+    {
+        var importResponse = await client.ImportTableAsync(new ImportTableRequest
+        {
+            S3BucketSource = new S3BucketSource { S3Bucket = s3Bucket },
+            InputFormat = InputFormat.DYNAMODB_JSON,
+            TableCreationParameters = new TableCreationParameters
+            {
+                TableName = tableName,
+                KeySchema = [new KeySchemaElement { AttributeName = "PK", KeyType = KeyType.HASH }],
+                AttributeDefinitions = [new AttributeDefinition { AttributeName = "PK", AttributeType = ScalarAttributeType.S }]
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var importArn = importResponse.ImportTableDescription.ImportArn;
+
+        ImportTableDescription? description = null;
+        for (var i = 0; i < 100; i++)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+            var desc = await client.DescribeImportAsync(new DescribeImportRequest
+            {
+                ImportArn = importArn
+            }, TestContext.Current.CancellationToken);
+            description = desc.ImportTableDescription;
+            if (description.ImportStatus != ImportStatus.IN_PROGRESS)
+                break;
+        }
+
+        Assert.NotNull(description);
+        Assert.NotEqual(ImportStatus.IN_PROGRESS, description.ImportStatus);
+        return description;
+    }
+
+    [Fact]
+    public async Task Import_From_Nonexistent_Source_Path_Fails()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"dynamo_import_missing_{Guid.NewGuid():N}");
+        Assert.False(Directory.Exists(missingPath));
+
+        var description = await ImportAndWaitForTerminalStatusAsync(missingPath, "ImportMissingPathTable");
+
+        // Real DynamoDB fails an import whose source location has no valid data files.
+        // It must not silently report COMPLETED with zero items.
+        Assert.Equal(ImportStatus.FAILED, description.ImportStatus);
+        Assert.Equal(0, description.ImportedItemCount);
+    }
+
+    [Fact]
+    public async Task Import_From_Empty_Source_Path_Fails()
+    {
+        var emptyPath = Path.Combine(Path.GetTempPath(), $"dynamo_import_empty_{Guid.NewGuid():N}");
+        _ = Directory.CreateDirectory(emptyPath);
+        try
+        {
+            var description = await ImportAndWaitForTerminalStatusAsync(emptyPath, "ImportEmptyPathTable");
+
+            // Source path exists but contains no data files — must surface a failure,
+            // not a silent COMPLETED-with-zero-items success.
+            Assert.Equal(ImportStatus.FAILED, description.ImportStatus);
+            Assert.Equal(0, description.ImportedItemCount);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(emptyPath, true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Best-effort cleanup
+            }
+        }
+    }
+
     [Fact]
     public async Task ListImports_With_NextToken_Accepts_Continuation()
     {


### PR DESCRIPTION
Closes #17

## Problem

`ImportTableAsync` launches a background import; `ExecuteImportAsync` calls `ExportHelper.FindDataFiles` to locate data files. When the source path doesn't exist (or contains no export), `FindDataFiles` returned an empty list and the import completed with `ImportStatus = COMPLETED` and 0 items — a silent success that hides a misconfigured source.

## Behavior, grounded in real DynamoDB

Per the [AWS import validation docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataImport.Validation.html), DynamoDB fails an import when the **source location is missing/inaccessible** — e.g. a missing bucket yields `ImportStatus = FAILED`, `FailureCode = S3NoSuchBucket`. It does **not** document failing a *valid but empty* source, and the worked failure examples are all missing/inaccessible/malformed sources. So the correct contract is:

- **Source location absent** (no export at the path) → `FAILED` / `S3NoSuchBucket`.
- **Valid export that legitimately contains zero items** (e.g. an empty-table export) → `COMPLETED` with 0 items, not `FAILED`.

## Change

`ExecuteImportAsync` now keys off the presence of the `AWSDynamoDB` export directory at the source rather than the data-file count. DynamoDbLite reuses the `S3Bucket` field as a local path, so the absence of that directory is the analog of "the source doesn't exist":

- No `AWSDynamoDB` dir → `FAILED`, `FailureCode = S3NoSuchBucket`.
- Present (even with zero data files) → import proceeds and completes with 0 items.

This fixes the reported silent-success bug **and** avoids wrongly failing a legitimate empty-table export round-trip (which a naive "fail when zero data files" check would regress — caught in review).

## Tests

- `Import_From_Nonexistent_Source_Path_Fails`, `Import_From_Empty_Source_Path_Fails` — assert `FAILED` + `FailureCode == "S3NoSuchBucket"` (run per store backend).
- `Export_And_Import_Empty_Table_Completes_With_Zero_Items` — exports an empty table and re-imports it, asserting `COMPLETED`, `ImportedItemCount == 0`, and an empty target table (both store backends).

Full suite green: 853 + 192, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)