### PR TITLE
Adopt canonical .editorconfig from scaffolding-csharp template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,51 +17,11 @@ insert_final_newline = true
 
 #### .NET Coding Conventions ####
 
-# Organize usings
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = false
-
-# this. and Me. preferences
-dotnet_style_qualification_for_event = true:suggestion
-dotnet_style_qualification_for_field = true:suggestion
-dotnet_style_qualification_for_method = true:suggestion
-dotnet_style_qualification_for_property = true:suggestion
-
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = false:suggestion
-
-# Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:silent
-
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-
-# Expression-level preferences
+# C#-only expression preferences. Language-agnostic dotnet_style_* / dotnet_code_quality_* /
+# dotnet_style_parentheses_* live under [*.{cs,vb}] below — do not re-declare them here.
 csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_return = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-
-# Field preferences
-dotnet_style_readonly_field = true:warning
-
-# Parameter preferences
-dotnet_code_quality_unused_parameters = all:warning
 
 #### C# Coding Conventions ####
 
@@ -90,7 +50,10 @@ csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:suggestion
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_style_prefer_unbound_generic_type_in_nameof = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
 
 # Code-block preferences
 csharp_prefer_braces = false:suggestion
@@ -98,7 +61,6 @@ csharp_prefer_simple_using_statement = true:warning
 
 # Expression-level preferences
 csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
 csharp_style_prefer_range_operator = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
@@ -253,7 +215,7 @@ dotnet_naming_style.camelcase.required_prefix =
 dotnet_naming_style.camelcase.required_suffix = 
 dotnet_naming_style.camelcase.word_separator = 
 dotnet_naming_style.camelcase.capitalization = camel_case
-csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_namespace_declarations = file_scoped:warning
 csharp_style_prefer_method_group_conversion = true:silent
 csharp_style_prefer_top_level_statements = true:silent
 csharp_style_prefer_null_check_over_type_check = true:suggestion
@@ -319,7 +281,7 @@ dotnet_diagnostic.IDE1006.severity = suggestion
 dotnet_diagnostic.IDE2000.severity = suggestion
 dotnet_diagnostic.IDE2002.severity = suggestion
 dotnet_diagnostic.IDE2004.severity = suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = false:suggestion
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 csharp_style_prefer_primary_constructors = true:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion
@@ -351,9 +313,6 @@ dotnet_diagnostic.IDE1005.severity = suggestion
 dotnet_diagnostic.IDE2003.severity = suggestion
 dotnet_diagnostic.IDE2005.severity = suggestion
 dotnet_diagnostic.IDE2006.severity = suggestion
-csharp_prefer_system_threading_lock = true:suggestion
-csharp_prefer_static_anonymous_function = true:suggestion
-csharp_style_prefer_unbound_generic_type_in_nameof = true:suggestion
 
 [*.{cs,vb}]
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
@@ -375,6 +334,14 @@ dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
+# Organize usings (dotnet_* — relocated here from [*.cs])
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+# Added 2026 — present in the current .NET default, previously absent
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_non_hidden_explicit_cast_in_source = true
+dotnet_prefer_system_hash_code = true
+dotnet_remove_unnecessary_suppression_exclusions = none
 dotnet_diagnostic.CA1000.severity = suggestion
 dotnet_diagnostic.CA1010.severity = suggestion
 dotnet_diagnostic.CA1036.severity = suggestion
@@ -399,7 +366,7 @@ dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
-dotnet_style_prefer_collection_expression = when_types_exactly_match:suggestion
+dotnet_style_prefer_collection_expression = true:suggestion
 dotnet_style_readonly_field = true:error
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
@@ -418,18 +385,3 @@ dotnet_diagnostic.CA5379.severity = suggestion
 dotnet_diagnostic.CA5384.severity = suggestion
 dotnet_diagnostic.CA5385.severity = suggestion
 dotnet_diagnostic.CA5397.severity = warning
-dotnet_diagnostic.CA2100.severity = warning
-dotnet_diagnostic.CA2153.severity = warning
-dotnet_diagnostic.CA3001.severity = warning
-dotnet_diagnostic.CA3003.severity = warning
-dotnet_diagnostic.CA3012.severity = warning
-dotnet_diagnostic.CA5394.severity = warning
-dotnet_diagnostic.CA2007.severity = none
-
-[tests/DynamoDbLite*.Tests/**.cs]
-dotnet_diagnostic.CA1307.severity = none
-dotnet_diagnostic.CA1515.severity = none
-dotnet_diagnostic.CA1812.severity = none
-dotnet_diagnostic.CA1816.severity = none
-dotnet_diagnostic.CA1852.severity = none
-dotnet_diagnostic.CA2214.severity = none


### PR DESCRIPTION
Replaces `.editorconfig` with the canonical config from the `scaffolding-csharp` skill template, so this repo matches what a freshly scaffolded solution gets.

Config-only change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)