### PR TITLE
Stub SearchVectorsAsync; add install section, correct TTL and storage-mode claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,31 @@ DynamoDbLite provides a drop-in replacement for the AWS DynamoDB SDK client, usi
 - **Reduced costs** during development by avoiding DynamoDB provisioned capacity charges
 - **Offline functionality** for applications that need DynamoDB-like behavior without cloud dependencies
 
+## Install
+
+```shell
+dotnet add package MSL.DynamoDbLite
+```
+
+The package id carries the publisher prefix; the assembly and namespace are `DynamoDbLite`.
+
+```csharp
+using DynamoDbLite;
+
+// in-memory, isolated per test run
+using var client = new DynamoDbClient(new DynamoDbLiteOptions(
+    $"Data Source=app_{Guid.NewGuid():N};Mode=Memory;Cache=Shared"));
+```
+
+Or register it for DI:
+
+```csharp
+builder.Services.AddDynamoDbLite(o =>
+    o.WithConnectionString("Data Source=myapp.db"));
+```
+
+A connection string is required; there is no default. See [Getting started](https://github.com/marklauter/DynamoDbLite/wiki/Getting-Started).
+
 ## Features
 
 - **Item CRUD** with `ConditionExpression`, `ProjectionExpression`, `UpdateExpression`, and `ReturnValues`
@@ -28,17 +53,17 @@ DynamoDbLite provides a drop-in replacement for the AWS DynamoDB SDK client, usi
 - **Paginators**: `client.Paginators` over all seven paged operations, single-use like the AWS SDK's own
 - **Transactions**: `TransactWriteItems` and `TransactGetItems` with all-or-nothing semantics, `ClientRequestToken` idempotency, and `ReturnValuesOnConditionCheckFailure`
 - **Secondary indexes**: GSI and LSI with sparse-index support, projection types `ALL`/`KEYS_ONLY`/`INCLUDE`, and `UpdateTable` GSI create/delete with backfill
-- **TTL**: `UpdateTimeToLive`, `DescribeTimeToLive`, read-time filtering, background cleanup
+- **TTL**: `UpdateTimeToLive`, `DescribeTimeToLive`, read-time filtering, inline sweep throttled per table
 - **Tags**: `TagResource`, `UntagResource`, `ListTagsOfResource`
 - **Export & Import**: file-system-backed analog of S3, `DYNAMODB_JSON` format
 - **DynamoDbContext compatibility**: works with the AWS SDK high-level ORM (object persistence, `[DynamoDBVersion]` optimistic locking, GSI queries)
-- **Two storage modes**: in-memory (default) for fast tests; file-based with WAL for persistence
+- **Two storage modes**: in-memory for fast tests; file-based with optional WAL for persistence
 - **AWS SDK v4** (`AWSSDK.DynamoDBv2` 4.0+)
 
 For the operation-by-operation support matrix and limitations, see the [API Parity](https://github.com/marklauter/DynamoDbLite/wiki/API-Parity) wiki page.
 
 ## Documentation
 
-- [Wiki](https://github.com/marklauter/DynamoDbLite/wiki) — usage guide, API reference, and behaviour notes
+- [Wiki](https://github.com/marklauter/DynamoDbLite/wiki) — usage guide, API reference, and behavior notes
 - [Decisions](docs/decisions/) — design rationale and phase status
 - [API Parity](https://github.com/marklauter/DynamoDbLite/wiki/API-Parity) — what's supported, what's stubbed, what's out of scope

--- a/docs/decisions/out-of-scope-operations.md
+++ b/docs/decisions/out-of-scope-operations.md
@@ -1,7 +1,7 @@
 ---
 title: Out-of-scope Operations
 type: decision
-summary: "Backups, global tables, Kinesis streaming, PartiQL, contributor insights, and resource policies are permanently out of scope. Superseded on the exception type only; the set of operations still stands."
+summary: "Backups, global tables, Kinesis streaming, PartiQL, contributor insights, resource policies, and vector search are permanently out of scope. Superseded on the exception type only; the set of operations still stands."
 tags: [scope, api-surface]
 created: 2026-05-16
 status: superseded
@@ -19,3 +19,17 @@ These operations are not meaningful for a local embedded emulator and will remai
 - **Kinesis streaming:** `EnableKinesisStreamingDestination` and related
 - **PartiQL:** `ExecuteStatement`, `BatchExecuteStatement`, `ExecuteTransaction`
 - **Contributor insights / resource policies**
+- **Vector search:** `SearchVectors`
+
+## Amendment, 2026-08-10
+
+`SearchVectors` was added to `IAmazonDynamoDB` in AWSSDK.DynamoDBv2 4.0.103, after this note was
+written, and joins the set for the same reason as the rest. Vector similarity search needs an
+approximate-nearest-neighbor index and configurable distance functions (`COSINE`, `EUCLIDEAN`,
+`DOT_PRODUCT`). SQLite has no analog, and building one is a different project.
+
+Adding a member to `IAmazonDynamoDB` is source-compatible for callers of the SDK and breaking for
+implementors of it. DynamoDbLite is an implementor, so an SDK release whose version suggests a patch
+can stop the build outright. Expect this on future SDK bumps: the fix is a stub in
+`DynamoDbClient.Unsupported.cs` when the operation is out of scope, and a scope decision when it
+is not.

--- a/src/DynamoDbLite/DynamoDbClient.Unsupported.cs
+++ b/src/DynamoDbLite/DynamoDbClient.Unsupported.cs
@@ -125,4 +125,12 @@ public sealed partial class DynamoDbClient
     public Task<PutResourcePolicyResponse> PutResourcePolicyAsync(PutResourcePolicyRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
     #endregion
+
+    #region Vector search
+
+    /// <summary>Not supported.</summary>
+    [ExcludeFromCodeCoverage]
+    public Task<SearchVectorsResponse> SearchVectorsAsync(SearchVectorsRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+    #endregion
 }

--- a/src/DynamoDbLite/SqliteStores/SqliteStore.cs
+++ b/src/DynamoDbLite/SqliteStores/SqliteStore.cs
@@ -138,7 +138,7 @@ internal abstract class SqliteStore
         // a CREATE INDEX prepared alongside the CREATE TABLE that defines its
         // columns fails because the table doesn't exist at prepare time.
         _ = connection.Execute("""
-            -- Partial index for the background TTL sweep; most items have no TTL,
+            -- Partial index for the TTL sweep; most items have no TTL,
             -- so excluding NULL rows keeps the index small.
             CREATE INDEX IF NOT EXISTS idx_items_ttl_epoch
                 ON items (ttl_epoch)


### PR DESCRIPTION
Unblocks the build against AWSSDK.DynamoDBv2 4.0.103, and corrects README claims that no longer match the code.

## Build fix

4.0.103 adds `SearchVectorsAsync` to `IAmazonDynamoDB`. Adding an interface member is source-compatible for *callers* of the SDK but breaking for an *implementor*, which is what `DynamoDbClient` is — so `main` has not compiled since #112 auto-merged:

```
error CS0535: 'DynamoDbClient' does not implement interface member
'IAmazonDynamoDB.SearchVectorsAsync(SearchVectorsRequest, CancellationToken)'
```

Vector similarity search needs an ANN index and configurable distance functions (`COSINE`, `EUCLIDEAN`, `DOT_PRODUCT`) that SQLite has no analog for, so it joins the out-of-scope set alongside PartiQL, Streams, and backups: a `[ExcludeFromCodeCoverage]` stub throwing `NotSupportedException` in `DynamoDbClient.Unsupported.cs`, under a new `Vector search` region, matching the existing convention.

## Docs

- **Install section** in the README, ahead of the feature list — the README predated the NuGet release and had none.
- **TTL** described "background cleanup". The sweep runs inline on the read path, awaited, throttled per table, per [`no-background-work.md`](docs/decisions/no-background-work.md). Same reason for dropping "background" from the `ttl_epoch` partial-index comment in `SqliteStore.cs`.
- **Storage modes** claimed in-memory is the default. `DynamoDbLiteOptions.ConnectionString` is required and there is no default.
- **"behaviour" → "behavior"**.

## Verification

- `dotnet build DynamoDbLite.slnx -c Release` — clean, 0 warnings
- `dotnet test tests/DynamoDbLite.Tests` — 1071 passed, 0 failed; coverage 98.13% line / 87.39% branch
- `dotnet format DynamoDbLite.slnx --severity info --verify-no-changes` — clean

Parity tests were not run locally (they need a container runtime); CI covers them.

The matching wiki fixes for the same stale publishing, TTL, and export/import claims are already pushed. A wiki row for `SearchVectors` in the API-Parity out-of-scope list still needs adding — say the word and I'll push it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
